### PR TITLE
Fix duplicate symbols in _zend_* funcs (added externs)

### DIFF
--- a/aop.c
+++ b/aop.c
@@ -27,6 +27,8 @@
 #include "aop.h"
 #include "Zend/zend_operators.h"
 
+ZEND_DECLARE_MODULE_GLOBALS(aop)
+
 #define DEBUG_OBJECT_HANDLERS 1
 
 static void php_aop_init_globals(zend_aop_globals *aop_globals)

--- a/aop.h
+++ b/aop.h
@@ -216,8 +216,8 @@ static int pointcut_match_zend_function (pointcut *pc, zend_function *curr_func,
 static void (*zend_std_write_property)(zval *object, zval *member, zval *value TSRMLS_DC);
 #endif
 void _test_func_pointcut_and_execute(HashPosition pos, HashTable *ht, zend_execute_data *ex, zval *object, zend_class_entry *scope, zend_class_entry *called_scope, int args_overloaded, zval *args, zval **to_return_ptr_ptr);
-zval * (*zend_std_read_property)(zval *object, zval *member, int type AOP_KEY_D TSRMLS_DC);
-zval ** (*zend_std_get_property_ptr_ptr)(zval *object, zval *member AOP_KEY_D TSRMLS_DC);
+extern zval * (*zend_std_read_property)(zval *object, zval *member, int type AOP_KEY_D TSRMLS_DC);
+extern zval ** (*zend_std_get_property_ptr_ptr)(zval *object, zval *member AOP_KEY_D TSRMLS_DC);
 void _test_write_pointcut_and_execute(HashPosition pos, HashTable *ht, zval *object, zval *member, zval *value, zend_class_entry *current_scope AOP_KEY_D);
 static void execute_pointcut (pointcut *pointcut_to_execute, zval *arg);
 static int test_property_scope (pointcut *current_pc, zend_class_entry *ce, zval *member AOP_KEY_D);

--- a/aop.h
+++ b/aop.h
@@ -234,6 +234,4 @@ HashTable * get_cache_property (zval *object, zval *member, int type AOP_KEY_D);
 HashTable * get_cache_func (zval *object, zend_execute_data *ex);
 static void free_object_cache (void * cache);
 
-ZEND_DECLARE_MODULE_GLOBALS(aop)
-
 #endif


### PR DESCRIPTION
Fix duplicate symbols in _zend_\* funcs (added externs)
